### PR TITLE
submodule update fix

### DIFF
--- a/pan_cnc/lib/git_utils.py
+++ b/pan_cnc/lib/git_utils.py
@@ -300,6 +300,7 @@ def update_repo(repo_dir: str, branch=None):
 
         f = repo.git.pull('origin', current_branch)
         repo.git.submodule('update', '--init')
+        repo.submodule_update(recursive=True, init=True, force_reset=True, force_remove=True)
 
     except GitCommandError as gce:
         print(gce)

--- a/pan_cnc/lib/git_utils.py
+++ b/pan_cnc/lib/git_utils.py
@@ -299,7 +299,7 @@ def update_repo(repo_dir: str, branch=None):
                 return 'Local branch is up to date'
 
         f = repo.git.pull('origin', current_branch)
-        repo.submodule_update(recursive=True)
+        repo.git.submodule('update', '--init')
 
     except GitCommandError as gce:
         print(gce)


### PR DESCRIPTION
For some reason git python doesn't actually clone down the files when you switch branches from a branch without a submodule to one with a submodule. The submodule would be aware of the files it should have, but they wouldn't be on disk, which caused errors in panhandler.

Not 100% sure yet why but this fixed it for me, basically a different approach to the same command.